### PR TITLE
Add scrolloff plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Plugin | Description
 [`language_wren`](plugins/language_wren.lua?raw=1) | Syntax for the [Wren](http://wren.io/) programming language
 [`linter`](https://github.com/drmargarido/linters)* | Linters for multiple languages
 [`macmodkeys`](plugins/macmodkeys.lua?raw=1) | Remaps mac modkeys `command/option` to `ctrl/alt`
+[`scrolloff`](plugins/scrolloff.lua?raw=1) | Redefines scrolling behavior to disallow scrolling off the end or beginning of a file
 [`selectionhighlight`](plugins/selectionhighlight.lua?raw=1) | Highlights regions of code that match the current selection *([screenshot](https://user-images.githubusercontent.com/3920290/80710883-5f597c80-8ae7-11ea-97f0-76dfacc08439.png))*
 [`sort`](plugins/sort.lua?raw=1) | Sorts selected lines alphabetically
 [`spellcheck`](plugins/spellcheck.lua?raw=1) | Underlines misspelt words *([screenshot](https://user-images.githubusercontent.com/3920290/79923973-9caa7400-842e-11ea-85d4-7a196a91ca50.png))*

--- a/plugins/scrolloff.lua
+++ b/plugins/scrolloff.lua
@@ -1,0 +1,12 @@
+local View = require "core.view"
+local config = require "core.config"
+
+function View:on_mouse_wheel(y)
+  if self.scrollable then
+    self.scroll.to.y = self.scroll.to.y + y * -config.mouse_wheel_scroll
+     local x1, y1, x2, y2 = self:get_content_bounds()
+     self.scroll.to.y = math.max(math.min(self.scroll.to.y, math.max(self:get_scrollable_size() - (y2 - y1), 0) + config.scrolloff), -config.scrolloff)
+   end
+end
+
+config.scrolloff = 100


### PR DESCRIPTION
The current behavior of the editor is to continue scrolling past the end or beginning of a document, with nothing stopping it from scrolling indefinitely. This plugin bounds the scrolling, with a user-configurable parameter for how many pixels off the edge of the document you want to allow the viewport to scroll. 