### PR TITLE
Fixed lfautoinsert.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Plugin | Description
 [`lineguide`](plugins/lineguide.lua?raw=1) | Displays a line-guide at the line limit offset *([screenshot](https://user-images.githubusercontent.com/3920290/81476159-2cf70000-9208-11ea-928b-9dae3884c477.png))*
 [`linter`](https://github.com/drmargarido/linters)* | Linters for multiple languages
 [`macmodkeys`](plugins/macmodkeys.lua?raw=1) | Remaps mac modkeys `command/option` to `ctrl/alt`
+[`plugin_manager`](https://github.com/doczi-dominik/lite-plugin-manager)* | Simple tool to enable/disable plugins and inject them in-place
 [`selectionhighlight`](plugins/selectionhighlight.lua?raw=1) | Highlights regions of code that match the current selection *([screenshot](https://user-images.githubusercontent.com/3920290/80710883-5f597c80-8ae7-11ea-97f0-76dfacc08439.png))*
 [`sort`](plugins/sort.lua?raw=1) | Sorts selected lines alphabetically
 [`spellcheck`](plugins/spellcheck.lua?raw=1) | Underlines misspelt words *([screenshot](https://user-images.githubusercontent.com/3920290/79923973-9caa7400-842e-11ea-85d4-7a196a91ca50.png))*

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Plugin | Description
 [`lineguide`](plugins/lineguide.lua?raw=1) | Displays a line-guide at the line limit offset *([screenshot](https://user-images.githubusercontent.com/3920290/81476159-2cf70000-9208-11ea-928b-9dae3884c477.png))*
 [`linter`](https://github.com/drmargarido/linters)* | Linters for multiple languages
 [`macmodkeys`](plugins/macmodkeys.lua?raw=1) | Remaps mac modkeys `command/option` to `ctrl/alt`
-[`plugin_manager`](https://github.com/doczi-dominik/lite-plugin-manager)* | Simple tool to enable/disable plugins and inject them in-place
 [`selectionhighlight`](plugins/selectionhighlight.lua?raw=1) | Highlights regions of code that match the current selection *([screenshot](https://user-images.githubusercontent.com/3920290/80710883-5f597c80-8ae7-11ea-97f0-76dfacc08439.png))*
 [`sort`](plugins/sort.lua?raw=1) | Sorts selected lines alphabetically
 [`spellcheck`](plugins/spellcheck.lua?raw=1) | Underlines misspelt words *([screenshot](https://user-images.githubusercontent.com/3920290/79923973-9caa7400-842e-11ea-85d4-7a196a91ca50.png))*


### PR DESCRIPTION
Previously, `lfautoinsert` would insert the matching closing keyword every time Return is pressed on the opening tag.

Example (|| denotes cursor):
```lua
if asd then||

-- [ Pressed Return ]

if asd then
  ||
end

-- [ Backspace to go to the prev. line ]

if asd then||
end

-- [ Pressed Return ]

if asd then
  ||
end
end
```

Now `lfautoinsert` checks the next line and the level of indentation to determine whether to insert the closing character.

Let me know if you have any questions!