### PR TITLE
Plugin :: Copy file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Plugin | Description
 [`bracketmatch`](plugins/bracketmatch.lua?raw=1) | Underlines matching right-bracket of left-bracket under caret *([screenshot](https://user-images.githubusercontent.com/3920290/80132745-0c863f00-8594-11ea-8875-c455c6fd7eae.png))*
 [`colorpreview`](plugins/colorpreview.lua?raw=1) | Underlays color values (eg. `#ff00ff` or `rgb(255, 0, 255)`) with their resultant color. *([screenshot](https://user-images.githubusercontent.com/3920290/80743752-731bd780-8b15-11ea-97d3-847db927c5dc.png))*
 [`console`](https://github.com/rxi/console)* | A console for running external commands and capturing their output *([gif](https://user-images.githubusercontent.com/3920290/81343656-49325a00-90ad-11ea-8647-ff39d8f1d730.gif))*
+[`copyfilelocation`](plugins/copyfilelocation.lua?raw=1) | Copy file location to clipboard
 [`detectindent`](plugins/detectindent.lua?raw=1) | Automatically detects and uses the indentation size and tab type of a loaded file
 [`drawwhitespace`](plugins/drawwhitespace.lua?raw=1) | Draws tabs and spaces *([screenshot](https://user-images.githubusercontent.com/3920290/80573013-22ae5800-89f7-11ea-9895-6362a1c0abc7.png))*
 [`eval`](plugins/eval.lua?raw=1) | Replaces selected Lua code with its evaluated result

--- a/plugins/copyfilelocation.lua
+++ b/plugins/copyfilelocation.lua
@@ -1,0 +1,17 @@
+local core = require "core"
+local command = require "core.command"
+local config = require "core.config"
+
+
+command.add("core.docview", {
+  ["copy-file-location:copy-file-location"] = function()
+    local doc = core.active_view.doc
+    if not doc.filename then
+      core.error "Cannot copy location of unsaved doc"
+      return
+    end
+    local filename = system.absolute_path(doc.filename)
+    core.log("Copying to clipboard \"%s\"", filename)
+    system.set_clipboard(filename)
+  end
+})


### PR DESCRIPTION
Hi @rxi ,

I am sending a PR for the plugin.
If you dislike I will keep a separate repo and may be we can add a  link to it ?

What makes this plugin different from what you said in #31 .  `ctrl+shift+s`, `ctrl+a`, `ctrl+c` will only copy relative path. Not the absolute path. This plugin copies absolute path.

Thank you.