### PR TITLE
Support #fff format in colorpreview plugin

### DIFF
--- a/plugins/colorpreview.lua
+++ b/plugins/colorpreview.lua
@@ -7,7 +7,7 @@ local black = { common.color "#000000" }
 local tmp = {}
 
 
-local function draw_color_previews(self, idx, x, y, ptn, base)
+local function draw_color_previews(self, idx, x, y, ptn, base, nibbles)
   local text = self.doc.lines[idx]
   local s, e = 0, 0
 
@@ -18,6 +18,13 @@ local function draw_color_previews(self, idx, x, y, ptn, base)
     local str = text:sub(s, e)
     local r, g, b = str:match(ptn)
     r, g, b = tonumber(r, base), tonumber(g, base), tonumber(b, base)
+
+    -- #123 becomes #112233
+    if nibbles then
+      r = r * 16
+      g = g * 16
+      b = b * 16
+    end
 
     local x1 = x + self:get_col_x_offset(idx, s)
     local x2 = x + self:get_col_x_offset(idx, e + 1)
@@ -41,6 +48,6 @@ local draw_line_text = DocView.draw_line_text
 function DocView:draw_line_text(idx, x, y)
   draw_line_text(self, idx, x, y)
   draw_color_previews(self, idx, x, y, "#(%x%x)(%x%x)(%x%x)%f[%X]",        16)
+  draw_color_previews(self, idx, x, y, "#(%x)(%x)(%x)%f[%X]",              16, true) -- support #fff css format
   draw_color_previews(self, idx, x, y, "rgba?%((%d+)%D+(%d+)%D+(%d+).-%)", 10)
 end
-


### PR DESCRIPTION
In addition to #rrggbb, rgb(r,g,b) and rgba(r,g,b,a) this now also supports the other css standard format #rgb, i.e. #123 becomes #112233.

![snap20200518205559](https://user-images.githubusercontent.com/49284552/82249679-879c0480-994a-11ea-9841-85a8f74e7632.png)
