### PR TITLE
Add basic makefile syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Plugin | Description
 [`language_hlsl`](plugins/language_hlsl.lua?raw=1) | Syntax for the [HLSL](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl) programming language
 [`language_hs`](plugins/language_hs.lua?raw=1) | Syntax for the [Haskell](https://www.haskell.org/) programming language
 [`language_jiyu`](plugins/language_jiyu.lua?raw=1) | Syntax for the [jiyu](https://github.com/machinamentum/jiyu) programming language
+[`language_make`](plugins/language_make.lua?raw=1) | Syntax for the Make build system language
 [`language_odin`](plugins/language_odin.lua?raw=1) | Syntax for the [Odin](https://github.com/odin-lang/Odin) programming language
 [`language_php`](plugins/language_php.lua?raw=1) | Syntax for the [PHP](https://php.net) programming language
 [`language_psql`](plugins/language_psql.lua?raw=1) | Syntax for the postgresql database access language

--- a/plugins/language_make.lua
+++ b/plugins/language_make.lua
@@ -1,0 +1,17 @@
+local syntax = require "core.syntax"
+
+syntax.add {
+  files = { "Makefile", "makefile", "%.mk$" },
+  comment = "#",
+  patterns = {
+    { pattern = "#.*\n",                  type = "comment"  },
+    { pattern = [[\.]],                   type = "normal"   },
+    { pattern = "$[@^<%%?+|*]",           type = "keyword2" },
+    { pattern = "$%(.-%)",                type = "variable" },
+    { pattern = "%f[%w_][%d%.]+%f[^%w_]", type = "number"   },
+    { pattern = "%..*:",                  type = "keyword2" },
+    { pattern = ".*:",                    type = "function" },
+  },
+  symbols = {
+  },
+}


### PR DESCRIPTION
I think this should be fairly helpful for folks dealing with Makefiles, was actually surprised to see it's not already supported.

Let me know if anything is wrong/needs to be fixed up.