### PR TITLE
Fixed openfilelocation.lua

### DIFF
--- a/plugins/openfilelocation.lua
+++ b/plugins/openfilelocation.lua
@@ -5,6 +5,8 @@ local config = require "core.config"
 
 if PLATFORM == "Windows" then
   config.filemanager = "explorer"
+elseif PLATFORM == "Mac OS X" then
+  config.filemanager = "open"
 else
   config.filemanager = "xdg-open"
 end


### PR DESCRIPTION
Previously `openfilelocation.lua` would not work correctly in macOS.

Now it works under macOS as intended.
