### PR TITLE
Add support for # as one-line comment for PHP

### DIFF
--- a/plugins/language_php.lua
+++ b/plugins/language_php.lua
@@ -5,6 +5,7 @@ syntax.add {
   comment = "//",
   patterns = {
     { pattern = "//.-\n",                 type = "comment"  },
+    { pattern = "#.-\n",                  type = "comment"  },
     { pattern = { "/%*", "%*/" },         type = "comment"  },
     -- I dont know why the '//' are needed but I leave it here for now
     { pattern = { '"', '"', '\\' },       type = "string"   },


### PR DESCRIPTION
See: https://www.php.net/manual/en/language.basic-syntax.comments.php