### PR TITLE
Fixed executing multiple commands in one go with exec:replace

### DIFF
--- a/plugins/exec.lua
+++ b/plugins/exec.lua
@@ -10,13 +10,18 @@ local function exec(cmd, keep_newline)
 end
 
 
+local function shell_quote(str)
+  return "'" .. str:gsub("'", "'\\''") .. "'"
+end
+
+
+local printfb_sub = {
+  ["\\"] = "\\\\",
+  ["\0"] = "\\0000",
+  ["'"] = "'\\''",
+}
 local function printfb_quote(str)
-  local sub = {
-    ["\\"] = "\\\\",
-    [string.char(0)] = "\\0000",
-    ["'"] = "'\\''",
-  }
-  return "'" .. str:gsub(".", sub) .. "'"
+  return "'" .. str:gsub(".", printfb_sub) .. "'"
 end
 
 
@@ -31,7 +36,7 @@ command.add("core.docview", {
     core.command_view:enter("Replace With Result Of Command", function(cmd)
       core.active_view.doc:replace(function(str)
         return exec(
-          "printf %b " .. printfb_quote(str:gsub("%\n$", "") .. "\n") .. " | " .. cmd,
+          "printf %b " .. printfb_quote(str:gsub("%\n$", "") .. "\n") .. " | eval '' " .. shell_quote(cmd),
           str:find("%\n$")
         )
       end)


### PR DESCRIPTION
By typing `dd bs=1 count=1; cat` (`dd bs=1 count=1` will consume 1 byte from the input, `cat` will consume the rest) in the prompt for exec:replace, the constructed command that will be executed will look like this : 
```sh
printf %b 'selected text' | dd bs=1 count=1; cat
```
The selected text will be piped to the first command only instead of the whole thing.

Using `eval`, the new code will make sure that what's typed in the prompt will be interpreted as a single entity without the possibility of interfering with the constructed command, like this :
```sh
printf %b 'selected text' | eval '' 'dd bs=1 count=1; cat'
```