### PR TITLE
bugfix: unable to quit lite bc of write error

### DIFF
--- a/plugins/workspace.lua
+++ b/plugins/workspace.lua
@@ -126,8 +126,12 @@ end
 local function save_workspace()
   local root = get_unlocked_root(core.root_view.root_node)
   local fp = io.open(workspace_filename, "w")
-  fp:write("return ", serialize(save_node(root)), "\n")
-  fp:close()
+  if nil ~= fp then
+    fp:write("return ", serialize(save_node(root)), "\n")
+    fp:close()
+  else
+    core.error("Failed to write workspace to: " .. workspace_filename)
+  end
 end
 
 


### PR DESCRIPTION
when lite is launched with a path to a read only directory
workspace plugin can not write, throws an error about
attempting to index nil, and does not quit.
This check allows quitting cleanly.