### PR TITLE
Run plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Plugin | Description
 [`motiontrail`](plugins/motiontrail.lua?raw=1) | Adds a motion-trail to the caret *([screenshot](https://user-images.githubusercontent.com/3920290/83256814-085ccb00-a1ab-11ea-9e35-e6633cbed1a9.gif))*
 [`openfilelocation`](plugins/openfilelocation.lua?raw=1) | Opens the parent directory of the current file in the file manager
 [`openselected`](plugins/openselected.lua?raw=1) | Opens the selected filename or url
+[`run`](plugins/run.lua?raw=1) | Runs the currently open file in a terminal window (`f5` or `run:run-doc`)
 [`scale`](plugins/scale.lua?raw=1) | Provides support for dynamically adjusting the scale of the code font / UI (`ctrl+-`, `ctrl+=`)
 [`scalestatus`](plugins/scalestatus.lua?raw=1) | Displays current scale (zoom) in status view (depends on scale plugin)
 [`selectionhighlight`](plugins/selectionhighlight.lua?raw=1) | Highlights regions of code that match the current selection *([screenshot](https://user-images.githubusercontent.com/3920290/80710883-5f597c80-8ae7-11ea-97f0-76dfacc08439.png))*

--- a/plugins/run.lua
+++ b/plugins/run.lua
@@ -1,0 +1,71 @@
+local core = require "core"
+local common = require "core.common"
+local command = require "core.command"
+local config = require "core.config"
+local keymap = require "core.keymap"
+
+local run = {}
+
+-- return a function which will run the current doc
+-- as a script for the given language
+function run.lang(lang)
+  return function()
+    core.log "Running a file..."
+    local cmd = assert(config.run[lang]):format(
+      "\"" .. core.active_view.doc.filename .. "\""
+    )
+
+    os.execute(config.run_cmd:format(cmd))
+  end
+end
+
+-- file extensions and functions
+config.run_files = {
+  ["%.py$"] = run.lang "python",
+  ["%.pyw$"] = run.lang "python",
+  ["%.lua$"] = run.lang "lua",
+  ["%.c$"] = run.lang "c",
+}
+
+-- system commands for running files
+-- the filename is already quoted
+config.run = {
+  python = "python %s",
+  lua = "lua %s",
+  c = "gcc %s && " .. (PLATFORM == "Windows" and "a.exe" or "./a.out"),
+}
+
+-- for systems other than Windows
+if PLATFORM == "Windows" then
+  config.run_cmd = "start cmd /c \"call %s & pause\""
+else
+  config.run_cmd = "gnome-terminal -x sh -c \"%s; bash\""
+end
+
+-- run the current doc based on its extension
+function run.run_file(this)
+  local doc = core.active_view.doc
+  if doc.filename then
+    doc:save()
+  else
+    core.error("Cannot run an unsaved file")
+    return
+  end
+
+  for pattern, func in pairs(config.run_files) do
+    if common.match_pattern(doc.filename, pattern) then
+      func()
+      break
+    end
+  end
+end
+
+command.add("core.docview", {
+  ["run:run-doc"] = run.run_file,
+})
+
+keymap.add {
+  ["f5"] = "run:run-doc",
+}
+
+return run


### PR DESCRIPTION
- You can either press `f5` or use the `run:run-doc` command
- I have only tested it on Windows
- New languages/compilers/interpreters can be added like this:
```lua
local config = require "core.config"
local run = require "plugins.run"

-- add system command command for the go language
config.run.go = "go run %s"
-- for file matching this format use the go language
config.run_files["%.go$"] = run.lang "go"

-- use tcc instead of gcc
config.run.c = "tcc -run %s"
```
You can also add, for example, love2d support to your project module
```lua
local config = require "core.config"
local run = require "plugins.run"

config.run.love2d = "love ."
config.run_files["^main.lua$"] = run.lang "love2d"
```
In this case `main.lua` would have to be the active doc
