### PR TITLE
Added homeuserdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Plugin | Description
 [`gofmt`](plugins/gofmt.lua?raw=1) | Auto-formats the current go file, adds the missing imports and the missing return cases
 [`hidelinenumbers`](plugins/hidelinenumbers.lua?raw=1) | Hides the line numbers on the left of documents *([screenshot](https://user-images.githubusercontent.com/3920290/81692043-b8b19c00-9455-11ea-8d74-ad99be4b9c5f.png))*
 [`hidestatus`](plugins/hidestatus.lua?raw=1) | Hides the status bar at the bottom of the window
+[`homeuserdata`](plugins/homeuserdata.lua?raw=1) | Loads init.lua from ~/.config/lite or ~/.lite, allowing you to save plugins or color themes on these directories and adds the 'Open Home User Module' command.
 [`inanimate`](plugins/inanimate.lua?raw=1) | Disables all transition animations
 [`indentguide`](plugins/indentguide.lua?raw=1) | Adds indent guides *([screenshot](https://user-images.githubusercontent.com/3920290/79640716-f9860000-818a-11ea-9c3b-26d10dd0e0c0.png))*
 [`language_angelscript`](plugins/language_angelscript.lua?raw=1) | Syntax for the [Angelscript](https://www.angelcode.com/angelscript/) programming language

--- a/plugins/homeuserdata.lua
+++ b/plugins/homeuserdata.lua
@@ -1,0 +1,76 @@
+local core = require "core"
+local command = require "core.command"
+local CommandView = require "core.commandview"
+
+-- don't execute plugin on windows
+if package.cpath:match("%p[\\|/]?%p(%a+)") == "dll" then
+  return
+end
+
+-- check if home directory is set
+local home_dir = os.getenv("HOME")
+
+if not home_dir then
+  return
+end
+
+-- user configurations path in order of preference
+local configs = {
+  home_dir .. "/.config/lite",
+  home_dir .. "/.lite"
+}
+
+-- load user settings
+for i,dir in ipairs(configs) do
+  local redirect = " 2>/dev/null"
+  if system.get_file_info(dir) then
+    package.path = package.path .. ";" .. dir .. "/?/init.lua"
+    package.path = package.path .. ";" .. dir .. "/?.lua"
+
+    if system.get_file_info(dir .. "/init.lua") then
+      local init = loadfile(dir .. "/init.lua")
+      init()
+    end
+
+    break
+  end
+end
+
+command.add(nil, {
+  ["core:open-home-user-module"] = function()
+    local directory = nil
+    for i,dir in ipairs(configs) do
+      local redirect = " 2>/dev/null"
+      if system.get_file_info(dir) then
+        directory = dir
+      end
+    end
+    if not directory then
+      directory = home_dir .. "/.config/lite"
+      os.execute("mkdir -p " .. directory)
+    end
+
+    local filename = directory .. "/init.lua"
+
+    if system.get_file_info(filename) then
+      core.root_view:open_doc(core.open_doc(filename))
+    else
+      local doc = core.open_doc()
+      core.root_view:open_doc(doc)
+
+      local content = "-- put user settings here\n\n"
+        .. "local keymap = require \"core.keymap\"\n"
+        .. "local config = require \"core.config\"\n"
+        .. "local style = require \"core.style\"\n\n"
+        .. "-- load plugins from " .. directory .. "/plugins:\n"
+        .. "-- require \"plugins.myplugin\"\n\n"
+        .. "-- load themes from " .. directory .. "/colors:\n"
+        .. "-- require \"colors.mytheme\"\n\n"
+        .. "-- key binding:\n"
+        .. "-- keymap.add { [\"ctrl+escape\"] = \"core:quit\" }\n"
+
+      doc:insert(1, 1, content)
+      doc:save(filename)
+    end
+  end,
+})


### PR DESCRIPTION
This plugin allows a user to have its settings on ~/.config/lite/init.lua or ~/.lite/init.lua and adds one of those path to the package.path global variable to also let the user load plugins from one of those directories.

The plugin should solve https://github.com/rxi/lite/issues/112