### PR TITLE
Add new plugin: userconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,5 @@ Plugin | Description
 [`todotreeview`](https://github.com/drmargarido/TodoTreeView)* | Todo tree viewer for annotations in code like `TODO`, `BUG`, `FIX`, `IMPROVEMENT`
 [`togglesnakecamel`](plugins/togglesnakecamel.lua?raw=1) | Toggles symbols between `snake_case` and `camelCase`
 [`unboundedscroll`](plugins/unboundedscroll.lua?raw=1) | Allows scrolling outside the bounds of a document
+[`userconfig`](plugins/userconfig.lua?raw=1) | Replaces `data/user` with a correct app config directory. Ex: `~/.lite`. Supports XDG_CONFIG_HOME
 [`workspace`](plugins/workspace.lua?raw=1) | Retains project's layout and open documents between sessions

--- a/plugins/userconfig.lua
+++ b/plugins/userconfig.lua
@@ -1,0 +1,63 @@
+local core = require "core"
+local command = require "core.command"
+
+
+if system.list_dir(EXEDIR .. "/data/user") then
+  core.error("You must remove " .. EXEDIR .. "/data/user before using this plugin.")
+  print("You must remove " .. EXEDIR .. "/data/user before using this plugin.")
+  core.error("Tip: Move its to ~/.lite, but do not forget to rename init.lua to user.lua")
+  print("Tip: Move its to ~/.lite, but do not forget to rename init.lua to user.lua")
+  return
+end
+
+local home = os.getenv("HOME")
+local user_config_dir
+
+if home then
+  user_config_dir = home .. "/.lite/"
+  if os.getenv("XDG_CONFIG_HOME") then
+    if system.list_dir(os.getenv("XDG_CONFIG_HOME") .. "/lite/") then
+      user_config_dir = os.getenv("XDG_CONFIG_HOME") .. "/lite/"
+    end
+  end
+  if system.list_dir(home .. "/.config/lite/") then
+    user_config_dir = home .. "/.config/lite/"
+  end
+else
+  home = os.getenv("HOME")
+  user_config_dir = home .. "\\lite\\"
+end
+
+if not system.list_dir(user_config_dir) then
+  os.execute("mkdir " .. user_config_dir)
+  io.open(user_config_dir .. "user.lua", "w"):write([[
+-- put user settings here
+-- this module will be loaded after everything else when the application starts
+-- before loading a plugin or theme, you must put the files in the suitable places
+-- ex: put all themes in ]] .. user_config_dir .. [[colors
+
+local keymap = require "core.keymap"
+local config = require "core.config"
+local style = require "core.style"
+
+-- set theme:
+-- require "colors.summer"
+
+-- key binding:
+-- keymap.add { ["ctrl+escape"] = "core:quit" }
+
+-- load plugin:
+-- require "plugins_loader"
+]]):close()
+end
+
+package.path = package.path .. ";" .. user_config_dir .. "/?.lua"
+
+command.map["core:open-user-module"] = {
+  predicate = function() return true end,
+  perform = function()
+    core.root_view:open_doc(core.open_doc(user_config_dir .. "user.lua"))
+  end
+}
+
+return { user_config_dir = user_config_dir }


### PR DESCRIPTION
Fixes https://github.com/rxi/lite/issues/112 
Partially solves https://github.com/rxi/lite/issues/49
I know about the https://github.com/rxi/lite-plugins/pull/85 plugin. But I didn't like the way it was written, so I wrote mine from scratch. My version:
- Should support windows. Although I haven't tested
- Uses the existing `Core: Open User Module` command instead of introducing its own duplicate and confusing one
- Partially supports the [Freedesktop specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html). It respects `XDG_CONFIG_HOME` if specified
- Exports the path to the configuration folder for use in other plugins