### PR TITLE
Inclusion of char as keyword 2 in language_rust.lua

### DIFF
--- a/plugins/language_rust.lua
+++ b/plugins/language_rust.lua
@@ -70,6 +70,7 @@ syntax.add {
     ["f64"]    = "keyword2",
     ["f128"]    = "keyword2",
     ["String"]        = "keyword2",
+    ["char"] = "keyword2",
     ["&str"]     = "keyword2",
     ["bool"]       = "keyword2",
     ["true"]       = "literal",

--- a/plugins/language_rust.lua
+++ b/plugins/language_rust.lua
@@ -61,6 +61,7 @@ syntax.add {
     ["i128"]      = "keyword2",
     ["i16"]      = "keyword2",
     ["i8"]       = "keyword2",
+    ["u8"] 	= "keyword2",
     ["u16"]       = "keyword2",
     ["u32"]     = "keyword2",
     ["u64"]     = "keyword2",


### PR DESCRIPTION
added char as a keyword2
(For it to be highlighted as a recognized data type, i believe maybe in haste sir LaineZ may have unintentionally forgotten to include it), not sure though.