### PR TITLE
inclusion of char and u8 as keyword2 values in language_rust.lua file

### DIFF
--- a/plugins/language_rust.lua
+++ b/plugins/language_rust.lua
@@ -70,6 +70,7 @@ syntax.add {
     ["f64"]    = "keyword2",
     ["f128"]    = "keyword2",
     ["String"]        = "keyword2",
+    ["char"] = "keyword2",
     ["&str"]     = "keyword2",
     ["bool"]       = "keyword2",
     ["true"]       = "literal",

--- a/plugins/language_rust.lua
+++ b/plugins/language_rust.lua
@@ -61,6 +61,7 @@ syntax.add {
     ["i128"]      = "keyword2",
     ["i16"]      = "keyword2",
     ["i8"]       = "keyword2",
+    ["u8"] 	= "keyword2",
     ["u16"]       = "keyword2",
     ["u32"]     = "keyword2",
     ["u64"]     = "keyword2",


### PR DESCRIPTION
char and u8 have now been included as highlight-able data types