### PR TITLE
add CloseConfirmX

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Plugin | Description
 [`black`](https://git.sr.ht/~tmpod/black-lite)* | Integrates the [black](https://github.com/psf/black) Python formatter with lite
 [`bracketmatch`](plugins/bracketmatch.lua?raw=1) | Underlines matching pair for bracket under the caret *([screenshot](https://user-images.githubusercontent.com/3920290/80132745-0c863f00-8594-11ea-8875-c455c6fd7eae.png))*
 [`centerdoc`](plugins/centerdoc.lua?raw=1) | Centers document's content on the screen *([screenshot](https://user-images.githubusercontent.com/3920290/82127896-bf6e4500-97ae-11ea-97fc-ba9a552bc9a4.png))*
+[`closeconfirmx`](plugins/closeconfirmx.lua?raw=1) | Replaces a system close confirmation dialog with a command view, like for individual files *([screenshot](https://user-images.githubusercontent.com/1689801/107596774-afa76280-6c53-11eb-80ab-22e73058c097.png))*
 [`colorpreview`](plugins/colorpreview.lua?raw=1) | Underlays color values (eg. `#ff00ff` or `rgb(255, 0, 255)`) with their resultant color. *([screenshot](https://user-images.githubusercontent.com/3920290/80743752-731bd780-8b15-11ea-97d3-847db927c5dc.png))*
 [`console`](https://github.com/rxi/console)* | A console for running external commands and capturing their output *([gif](https://user-images.githubusercontent.com/3920290/81343656-49325a00-90ad-11ea-8647-ff39d8f1d730.gif))*
 [`copyfilelocation`](plugins/copyfilelocation.lua?raw=1) | Copy file location to clipboard

--- a/plugins/closeconfirmx.lua
+++ b/plugins/closeconfirmx.lua
@@ -1,0 +1,54 @@
+-- CloseConfirmX plugin for lite text editor
+-- implementation by chekoopa
+
+local core = require "core"
+local config = require "core.config"
+
+config.closeconfirmx_use_legacy = false
+config.closeconfirmx_use_short_name = true
+
+local legacy_confirm = core.confirm_close_all
+
+local function commandful_confirm()
+  local dirty_count = 0
+  local dirty_name
+  for _, doc in ipairs(core.docs) do
+    if doc:is_dirty() then
+      dirty_count = dirty_count + 1
+      dirty_name = doc:get_name()
+    end
+  end
+  if dirty_count > 0 then
+    local text
+    if dirty_count == 1 then
+      if config.closeconfirmx_use_short_name then
+         dirty_name = dirty_name:match("[^/%\\]*$")
+      end
+      text = string.format("Unsaved changes in \"%s\"; Confirm Exit", dirty_name)
+    else
+      text = string.format("Unsaved changes in %d docs; Confirm Exit", dirty_count)
+    end
+    core.command_view:enter(text, function(_, item)
+      if item.text:match("^[cC]") then
+        core.quit(true)
+      end
+    end, function(text)
+      local items = {}
+      if not text:find("^[^sS]") then table.insert(items, "Stay here") end
+      if not text:find("^[^cC]") then table.insert(items, "Close Without Saving") end
+      return items
+    end)
+    -- as we delegate a choice inside the callback,
+    return false
+  end
+  return true
+end
+
+function core.confirm_close_all()
+  if config.closeconfirmx_use_legacy then
+    return legacy_confirm()
+  else
+    return commandful_confirm()
+  end
+end
+


### PR DESCRIPTION
A simple plugin which replaces the system close dialog to same command-based confirmation, as for individual files.

Also, relieves a problem with tiling WMs, especially when Lite is opened in fullscreen (is that system dialog modal?).